### PR TITLE
Add deploy script and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: deploy
+
+DEPLOY_HOST ?= $(shell git config deploy.host)
+
+deploy:
+	ssh ubuntu@$(DEPLOY_HOST) "bash ~/go-han/deploy.sh"

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+cd ~/go-han
+
+echo "[deploy] git pull..."
+git fetch origin
+git rebase origin/main
+
+echo "[deploy] building & restarting backend/frontend..."
+docker compose up -d --build --no-deps backend frontend
+
+echo "[deploy] done."
+docker compose ps


### PR DESCRIPTION
Rebuilds and restarts only backend/frontend containers without touching postgres. Deploy host is read from git config (deploy.host) to avoid hardcoding IP in the repository.

Usage:
  git config deploy.host <host>
  make deploy