### PR TITLE
feat: add is_cook / is_eater role attributes to users

### DIFF
--- a/backend/integration_test.go
+++ b/backend/integration_test.go
@@ -235,6 +235,88 @@ func TestGetMealsWeekdayDefaultsIntegration(t *testing.T) {
 	}`, w.Body.String())
 }
 
+// TestGetUsersIntegration verifies that GET /api/users returns all users with
+// correct is_cook and is_eater values.
+func TestGetUsersIntegration(t *testing.T) {
+	cleanup := startPostgres(t)
+	defer cleanup()
+
+	_, err := db.Exec(`
+		INSERT INTO users (id, name, is_cook, is_eater) VALUES
+			(1, 'Mother', true,  false),
+			(2, 'Father', true,  true),
+			(3, 'Taro',   false, true);
+	`)
+	require.NoError(t, err)
+
+	r := setupRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/users", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `[
+		{"id":1,"name":"Mother","is_cook":true,"is_eater":false},
+		{"id":2,"name":"Father","is_cook":true,"is_eater":true},
+		{"id":3,"name":"Taro","is_cook":false,"is_eater":true}
+	]`, w.Body.String())
+}
+
+// TestUpdateUserRolesIntegration verifies that PUT /api/users/:user_id/roles
+// correctly updates both flags and that a subsequent GET /api/users reflects the change.
+func TestUpdateUserRolesIntegration(t *testing.T) {
+	cleanup := startPostgres(t)
+	defer cleanup()
+
+	_, err := db.Exec(`INSERT INTO users (id, name) VALUES (1, 'Taro');`)
+	require.NoError(t, err)
+
+	r := setupRouter()
+
+	// Taro starts as is_cook=false, is_eater=true (defaults).
+	// Promote Taro to cook+eater.
+	body := bytes.NewBufferString(`{"is_cook":true,"is_eater":true}`)
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/users/1/roles", body)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	w2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest("GET", "/api/users", nil)
+	r.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusOK, w2.Code)
+	assert.JSONEq(t, `[{"id":1,"name":"Taro","is_cook":true,"is_eater":true}]`, w2.Body.String())
+}
+
+// TestGetMealsEaterFilterIntegration verifies that users with is_eater=false
+// do not appear in the GET /api/meals response.
+func TestGetMealsEaterFilterIntegration(t *testing.T) {
+	cleanup := startPostgres(t)
+	defer cleanup()
+
+	_, err := db.Exec(`
+		INSERT INTO users (id, name, is_cook, is_eater) VALUES
+			(1, 'Mother', true,  false),
+			(2, 'Father', true,  true);
+		INSERT INTO meal_periods (id) VALUES (1), (2);
+		INSERT INTO meal_options (id) VALUES (1), (2), (3);
+	`)
+	require.NoError(t, err)
+
+	r := setupRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/meals?date=2025-02-16&days=1", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Mother (is_eater=false) must not appear; only Father should.
+	body := w.Body.String()
+	assert.NotContains(t, body, "Mother")
+	assert.Contains(t, body, "Father")
+}
+
 // TestGetMealsNoDefaultsIntegration verifies COALESCE fallback when a user has
 // no entry in user_defaults: defaultLunch and defaultDinner must be 1 (なし).
 func TestGetMealsNoDefaultsIntegration(t *testing.T) {

--- a/backend/main.go
+++ b/backend/main.go
@@ -18,6 +18,14 @@ import (
 
 var db *sql.DB
 
+// User represents a user with their role attributes.
+type User struct {
+	ID      int    `json:"id"`
+	Name    string `json:"name"`
+	IsCook  bool   `json:"is_cook"`
+	IsEater bool   `json:"is_eater"`
+}
+
 // Meal represents meal information for a user on a specific date.
 type Meal struct {
 	UserID        int    `json:"user_id"`
@@ -80,6 +88,7 @@ const getMealsQuery = `
         LEFT JOIN meals m ON m.user_id = u.id AND m.date = d.date
         LEFT JOIN user_defaults ud ON ud.user_id = u.id
             AND ud.day_of_week = EXTRACT(DOW FROM d.date)
+        WHERE u.is_eater = true
         GROUP BY u.id, u.name, d.date, ud.lunch, ud.dinner
         ORDER BY d.date, u.id`
 
@@ -236,6 +245,54 @@ func sendSlackNotification(messages []string) {
    }
 }
 
+// getUsers returns all users with their role attributes.
+func getUsers(c *gin.Context) {
+	rows, err := db.Query("SELECT id, name, is_cook, is_eater FROM users ORDER BY id")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	defer rows.Close()
+	users := []User{}
+	for rows.Next() {
+		var u User
+		if err := rows.Scan(&u.ID, &u.Name, &u.IsCook, &u.IsEater); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		users = append(users, u)
+	}
+	c.JSON(http.StatusOK, users)
+}
+
+// updateUserRoles updates the is_cook / is_eater flags for a specific user.
+func updateUserRoles(c *gin.Context) {
+	userID := c.Param("user_id")
+	var req struct {
+		IsCook  bool `json:"is_cook"`
+		IsEater bool `json:"is_eater"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	result, err := db.Exec("UPDATE users SET is_cook = $1, is_eater = $2 WHERE id = $3", req.IsCook, req.IsEater, userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if n == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "User roles updated"})
+}
+
 // getUserDefaults returns the default meal settings for a specific user.
 func getUserDefaults(c *gin.Context) {
 	userID := c.Param("user_id")
@@ -302,6 +359,8 @@ func main() {
 
 	r := gin.Default()
 	r.GET("/api/health", healthCheck)
+	r.GET("/api/users", getUsers)
+	r.PUT("/api/users/:user_id/roles", updateUserRoles)
 	r.GET("/api/meals", getMeals)
 	r.PUT("/api/meals/bulk-update", bulkUpdateMeals)
 	r.GET("/api/user-defaults/:user_id", getUserDefaults)

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -20,6 +20,8 @@ func setupRouter() *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.Default()
 	r.GET("/health", healthCheck)
+	r.GET("/api/users", getUsers)
+	r.PUT("/api/users/:user_id/roles", updateUserRoles)
 	r.GET("/api/meals", getMeals)
 	r.PUT("/api/meals/bulk-update", bulkUpdateMeals)
 	r.GET("/api/user-defaults/:user_id", getUserDefaults)
@@ -177,6 +179,77 @@ func TestGetUserDefaults(t *testing.T) {
         {"day_of_week":6, "lunch":3, "dinner":1, "user_id":4}
     ]`
 	assert.JSONEq(t, expectedJSON, w.Body.String())
+}
+
+// TestGetUsers verifies the GET /api/users endpoint.
+func TestGetUsers(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer mockDB.Close()
+	db = mockDB
+
+	rows := sqlmock.NewRows([]string{"id", "name", "is_cook", "is_eater"}).
+		AddRow(1, "Mother", true, false).
+		AddRow(2, "Father", true, true).
+		AddRow(3, "Taro", false, true)
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT id, name, is_cook, is_eater FROM users ORDER BY id")).
+		WillReturnRows(rows)
+
+	r := setupRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/users", nil)
+	r.ServeHTTP(w, req)
+	t.Log("\n", func() string { var b bytes.Buffer; json.Indent(&b, w.Body.Bytes(), "", "  "); return b.String() }())
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	expected := `[
+		{"id":1,"name":"Mother","is_cook":true,"is_eater":false},
+		{"id":2,"name":"Father","is_cook":true,"is_eater":true},
+		{"id":3,"name":"Taro","is_cook":false,"is_eater":true}
+	]`
+	assert.JSONEq(t, expected, w.Body.String())
+}
+
+// TestUpdateUserRoles verifies the PUT /api/users/:user_id/roles endpoint.
+func TestUpdateUserRoles(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer mockDB.Close()
+	db = mockDB
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE users SET is_cook = $1, is_eater = $2 WHERE id = $3")).
+		WithArgs(true, false, "1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	payload := `{"is_cook":true,"is_eater":false}`
+	r := setupRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/users/1/roles", bytes.NewBufferString(payload))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	t.Log("\n", func() string { var b bytes.Buffer; json.Indent(&b, w.Body.Bytes(), "", "  "); return b.String() }())
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `{"message":"User roles updated"}`, w.Body.String())
+}
+
+// TestUpdateUserRolesNotFound verifies 404 when user_id does not exist.
+func TestUpdateUserRolesNotFound(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer mockDB.Close()
+	db = mockDB
+
+	mock.ExpectExec(regexp.QuoteMeta("UPDATE users SET is_cook = $1, is_eater = $2 WHERE id = $3")).
+		WithArgs(false, true, "99").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	payload := `{"is_cook":false,"is_eater":true}`
+	r := setupRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/users/99/roles", bytes.NewBufferString(payload))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 // TestUpdateUserDefaults verifies the PUT /api/user-defaults/:user_id endpoint.

--- a/db/02_init_schema.sql
+++ b/db/02_init_schema.sql
@@ -1,7 +1,9 @@
 -- Users table to store user information
 CREATE TABLE IF NOT EXISTS users (
     id SERIAL PRIMARY KEY,
-    name TEXT NOT NULL
+    name TEXT NOT NULL,
+    is_cook  BOOL NOT NULL DEFAULT false,
+    is_eater BOOL NOT NULL DEFAULT true
 );
 
 CREATE TABLE IF NOT EXISTS meal_periods (

--- a/db/04_add_user_roles.sql
+++ b/db/04_add_user_roles.sql
@@ -1,0 +1,6 @@
+-- Migration: add is_cook / is_eater role columns to users table.
+-- Safe to run on a live database: ADD COLUMN with DEFAULT does not rewrite the
+-- table in PostgreSQL 11+ and is effectively instantaneous.
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS is_cook  BOOL NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS is_eater BOOL NOT NULL DEFAULT true;

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,6 +11,8 @@
 | メソッド | パス | 概要 |
 |--------|------|------|
 | GET | `/api/health` | ヘルスチェック |
+| GET | `/api/users` | 全ユーザー一覧（ロール情報含む）取得 |
+| PUT | `/api/users/:user_id/roles` | ユーザーのロール更新 |
 | GET | `/api/meals` | 指定期間の食事予定一覧取得 |
 | PUT | `/api/meals/bulk-update` | 複数食事予定の一括更新 |
 | GET | `/api/user-defaults/:user_id` | ユーザーのデフォルト設定取得 |
@@ -21,6 +23,40 @@
 ### GET `/api/health`
 
 DBへのping結果を返す。起動確認・死活監視用。
+
+---
+
+### GET `/api/users`
+
+全ユーザーをロール情報付きで返す。
+
+**レスポンス例**
+
+```json
+[
+  { "id": 1, "name": "Mother", "is_cook": true,  "is_eater": false },
+  { "id": 2, "name": "Father", "is_cook": true,  "is_eater": true  },
+  { "id": 3, "name": "Taro",   "is_cook": false, "is_eater": true  }
+]
+```
+
+---
+
+### PUT `/api/users/:user_id/roles`
+
+指定ユーザーの `is_cook` / `is_eater` を更新する。
+
+**リクエストボディ例**
+
+```json
+{ "is_cook": true, "is_eater": false }
+```
+
+**設計上のポイント**
+
+- 両方 `true` も有効（例: Father）。
+- `is_eater=false` にすると `GET /api/meals` の結果から除外される。
+- 存在しない `user_id` の場合は `404` を返す。
 
 ---
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -7,6 +7,8 @@ erDiagram
     users {
         int id PK
         text name
+        bool is_cook
+        bool is_eater
     }
     meals {
         int id PK
@@ -38,12 +40,18 @@ erDiagram
 
 ### `users`
 
-ユーザー情報。
+ユーザー情報とロール属性。
 
-| カラム | 型 | 制約 |
-|-------|-----|------|
-| id | SERIAL | PK |
-| name | TEXT | NOT NULL |
+| カラム | 型 | 制約 | デフォルト |
+|-------|-----|------|---------|
+| id | SERIAL | PK | — |
+| name | TEXT | NOT NULL | — |
+| is_cook | BOOL | NOT NULL | false |
+| is_eater | BOOL | NOT NULL | true |
+
+`is_cook=true` のユーザーが料理担当、`is_eater=true` のユーザーが食事予定管理の対象となる。両方 `true` も可（例: Father）。
+
+`GET /api/meals` は `is_eater=true` のユーザーのみを返す。
 
 ---
 


### PR DESCRIPTION
- Add is_cook (default false) and is_eater (default true) columns to users table
- Filter GET /api/meals to is_eater=true users only (no visual change for existing users)
- Add GET /api/users and PUT /api/users/:user_id/roles endpoints
- Add db/04_add_user_roles.sql migration for existing databases
- Add unit and integration tests for new endpoints and eater filter
- Update docs/database.md and docs/api.md