### PR TITLE
feat: add Mother user to init data, remove applied migration

### DIFF
--- a/db/03_init_data.sql.example
+++ b/db/03_init_data.sql.example
@@ -6,6 +6,7 @@ INSERT INTO meal_options (id) VALUES (1), (2), (3);
 
 -- Insert sample users
 INSERT INTO users (name) VALUES ('Saburo'), ('Jiro'), ('Taro'), ('Father');
+INSERT INTO users (name, is_cook, is_eater) VALUES ('Mother', true, false);
 
 INSERT INTO user_defaults (user_id, day_of_week, lunch, dinner) VALUES
 (1, 0, 2, 2),

--- a/db/04_add_user_roles.sql
+++ b/db/04_add_user_roles.sql
@@ -1,6 +1,0 @@
--- Migration: add is_cook / is_eater role columns to users table.
--- Safe to run on a live database: ADD COLUMN with DEFAULT does not rewrite the
--- table in PostgreSQL 11+ and is effectively instantaneous.
-ALTER TABLE users
-    ADD COLUMN IF NOT EXISTS is_cook  BOOL NOT NULL DEFAULT false,
-    ADD COLUMN IF NOT EXISTS is_eater BOOL NOT NULL DEFAULT true;


### PR DESCRIPTION
- Add Mother (is_cook=true, is_eater=false) to 03_init_data.sql.example
- Remove 04_add_user_roles.sql (migration already applied to all environments)