### PR TITLE
feat: cook schedule management — assign cook per date/weekday, daily dashboard

### DIFF
--- a/backend/integration_test.go
+++ b/backend/integration_test.go
@@ -344,3 +344,216 @@ func TestGetMealsNoDefaultsIntegration(t *testing.T) {
 	}`
 	assert.JSONEq(t, expected, w.Body.String())
 }
+
+// seedCookUsers inserts one cook-only user (id=1) and one eater-only user (id=2)
+// for cook schedule integration tests.
+func seedCookUsers(t *testing.T) {
+	t.Helper()
+	_, err := db.Exec(`
+		INSERT INTO users (id, name, is_cook, is_eater) VALUES
+			(1, 'Cook', true, false),
+			(2, 'Eater', false, true);
+		INSERT INTO meal_periods (id) VALUES (1), (2);
+		INSERT INTO meal_options (id) VALUES (1), (2), (3);
+	`)
+	require.NoError(t, err)
+}
+
+// TestGetCookSchedulesPriorityIntegration covers all three resolution cases in a
+// single date range:
+//
+//	2025-02-16 (Sun, DOW=0): no default → lunch=null, dinner=null
+//	2025-02-17 (Mon, DOW=1): default=Cook for both; individual overrides lunch→Cook,
+//	                          dinner→NULL(explicit 各自)
+//	2025-02-18 (Tue, DOW=2): default=Cook for lunch only; no individual override
+//	                          → lunch falls back to default, dinner=null
+func TestGetCookSchedulesPriorityIntegration(t *testing.T) {
+	cleanup := startPostgres(t)
+	defer cleanup()
+	seedCookUsers(t)
+
+	_, err := db.Exec(`
+		INSERT INTO cook_default_schedules (day_of_week, meal_period, cook_user_id) VALUES
+			(1, 1, 1),
+			(1, 2, 1),
+			(2, 1, 1);
+		INSERT INTO cook_schedules (date, meal_period, cook_user_id) VALUES
+			('2025-02-17', 1, 1),
+			('2025-02-17', 2, NULL);
+	`)
+	require.NoError(t, err)
+
+	r := setupRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/cook-schedules?date=2025-02-16&days=3", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `{
+		"2025-02-16": {"lunch": null, "dinner": null},
+		"2025-02-17": {"lunch": {"cook_user_id":1,"cook_user_name":"Cook"}, "dinner": null},
+		"2025-02-18": {"lunch": {"cook_user_id":1,"cook_user_name":"Cook"}, "dinner": null}
+	}`, w.Body.String())
+}
+
+// TestGetCookSchedulesExplicitNullOverridesDefaultIntegration verifies that a row
+// with cook_user_id=NULL in cook_schedules suppresses the weekday default (各自 wins).
+func TestGetCookSchedulesExplicitNullOverridesDefaultIntegration(t *testing.T) {
+	cleanup := startPostgres(t)
+	defer cleanup()
+	seedCookUsers(t)
+
+	_, err := db.Exec(`
+		INSERT INTO cook_default_schedules (day_of_week, meal_period, cook_user_id) VALUES
+			(1, 1, 1);
+		INSERT INTO cook_schedules (date, meal_period, cook_user_id) VALUES
+			('2025-02-17', 1, NULL);
+	`)
+	require.NoError(t, err)
+
+	r := setupRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/cook-schedules?date=2025-02-17&days=1", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	// lunch must be null (explicit 各自), not the default Cook user
+	assert.JSONEq(t, `{
+		"2025-02-17": {"lunch": null, "dinner": null}
+	}`, w.Body.String())
+}
+
+// TestBulkUpdateCookSchedulesIntegration verifies upsert behaviour:
+// insert a new assignment, then overwrite it with a different value.
+func TestBulkUpdateCookSchedulesIntegration(t *testing.T) {
+	cleanup := startPostgres(t)
+	defer cleanup()
+	seedCookUsers(t)
+
+	r := setupRouter()
+
+	put := func(body string) {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/cook-schedules", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+
+	get := func() string {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/cook-schedules?date=2025-02-17&days=1", nil)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		return w.Body.String()
+	}
+
+	// Step 1: assign Cook to Mon lunch
+	put(`[{"date":"2025-02-17","meal_period":1,"cook_user_id":1}]`)
+	assert.JSONEq(t, `{"2025-02-17":{"lunch":{"cook_user_id":1,"cook_user_name":"Cook"},"dinner":null}}`, get())
+
+	// Step 2: overwrite Mon lunch with null (各自)
+	put(`[{"date":"2025-02-17","meal_period":1,"cook_user_id":null}]`)
+	assert.JSONEq(t, `{"2025-02-17":{"lunch":null,"dinner":null}}`, get())
+}
+
+// TestDeleteCookSchedulesIntegration verifies that DELETE removes the individual
+// override and the date falls back to the weekday default.
+func TestDeleteCookSchedulesIntegration(t *testing.T) {
+	cleanup := startPostgres(t)
+	defer cleanup()
+	seedCookUsers(t)
+
+	_, err := db.Exec(`
+		INSERT INTO cook_default_schedules (day_of_week, meal_period, cook_user_id) VALUES (1, 1, 1);
+		INSERT INTO cook_schedules (date, meal_period, cook_user_id) VALUES ('2025-02-17', 1, NULL);
+	`)
+	require.NoError(t, err)
+
+	r := setupRouter()
+
+	get := func() string {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/cook-schedules?date=2025-02-17&days=1", nil)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		return w.Body.String()
+	}
+
+	// Before delete: explicit NULL override → lunch=null
+	assert.JSONEq(t, `{"2025-02-17":{"lunch":null,"dinner":null}}`, get())
+
+	// Delete the override
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/cook-schedules",
+		bytes.NewBufferString(`[{"date":"2025-02-17","meal_period":1}]`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// After delete: falls back to weekday default → lunch=Cook
+	assert.JSONEq(t, `{"2025-02-17":{"lunch":{"cook_user_id":1,"cook_user_name":"Cook"},"dinner":null}}`, get())
+}
+
+// TestGetCookDefaultSchedulesIntegration verifies GET /api/cook-default-schedules.
+func TestGetCookDefaultSchedulesIntegration(t *testing.T) {
+	cleanup := startPostgres(t)
+	defer cleanup()
+	seedCookUsers(t)
+
+	_, err := db.Exec(`
+		INSERT INTO cook_default_schedules (day_of_week, meal_period, cook_user_id) VALUES
+			(1, 1, 1),
+			(1, 2, NULL);
+	`)
+	require.NoError(t, err)
+
+	r := setupRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/cook-default-schedules", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `[
+		{"day_of_week":1,"meal_period":1,"cook_user_id":1,"cook_user_name":"Cook"},
+		{"day_of_week":1,"meal_period":2,"cook_user_id":null,"cook_user_name":null}
+	]`, w.Body.String())
+}
+
+// TestUpdateCookDefaultSchedulesIntegration verifies upsert of weekday defaults.
+func TestUpdateCookDefaultSchedulesIntegration(t *testing.T) {
+	cleanup := startPostgres(t)
+	defer cleanup()
+	seedCookUsers(t)
+
+	r := setupRouter()
+
+	put := func(body string) {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("PUT", "/api/cook-default-schedules", bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+
+	get := func() string {
+		t.Helper()
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/api/cook-default-schedules", nil)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		return w.Body.String()
+	}
+
+	// Insert Mon lunch = Cook
+	put(`[{"day_of_week":1,"meal_period":1,"cook_user_id":1}]`)
+	assert.JSONEq(t, `[{"day_of_week":1,"meal_period":1,"cook_user_id":1,"cook_user_name":"Cook"}]`, get())
+
+	// Overwrite Mon lunch to null (各自)
+	put(`[{"day_of_week":1,"meal_period":1,"cook_user_id":null}]`)
+	assert.JSONEq(t, `[{"day_of_week":1,"meal_period":1,"cook_user_id":null,"cook_user_name":null}]`, get())
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -26,6 +26,47 @@ type User struct {
 	IsEater bool   `json:"is_eater"`
 }
 
+// CookAssignment represents the cook assigned to a meal period.
+// A nil pointer in DailyCookSchedule means 各自 (no designated cook).
+type CookAssignment struct {
+	CookUserID   int    `json:"cook_user_id"`
+	CookUserName string `json:"cook_user_name"`
+}
+
+// DailyCookSchedule holds the resolved cook assignments for a single day.
+type DailyCookSchedule struct {
+	Lunch  *CookAssignment `json:"lunch"`
+	Dinner *CookAssignment `json:"dinner"`
+}
+
+// CookScheduleUpdate is one element of the PUT /api/cook-schedules request body.
+type CookScheduleUpdate struct {
+	Date       string `json:"date"`
+	MealPeriod int    `json:"meal_period"`
+	CookUserID *int   `json:"cook_user_id"` // nil = 各自
+}
+
+// CookScheduleDelete is one element of the DELETE /api/cook-schedules request body.
+type CookScheduleDelete struct {
+	Date       string `json:"date"`
+	MealPeriod int    `json:"meal_period"`
+}
+
+// CookDefaultSchedule is the response element for GET /api/cook-default-schedules.
+type CookDefaultSchedule struct {
+	DayOfWeek    int     `json:"day_of_week"`
+	MealPeriod   int     `json:"meal_period"`
+	CookUserID   *int    `json:"cook_user_id"`
+	CookUserName *string `json:"cook_user_name"`
+}
+
+// CookDefaultScheduleUpdate is one element of the PUT /api/cook-default-schedules request body.
+type CookDefaultScheduleUpdate struct {
+	DayOfWeek  int  `json:"day_of_week"`
+	MealPeriod int  `json:"meal_period"`
+	CookUserID *int `json:"cook_user_id"` // nil = 各自
+}
+
 // Meal represents meal information for a user on a specific date.
 type Meal struct {
 	UserID        int    `json:"user_id"`
@@ -349,6 +390,234 @@ func updateUserDefaults(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "User defaults updated"})
 }
 
+// getCookSchedulesQuery resolves cook assignments for a date range.
+// Priority: cook_schedules (individual date) → cook_default_schedules (weekday) → nil (各自).
+// CASE WHEN cs.date IS NOT NULL distinguishes a row with NULL cook_user_id (explicit 各自,
+// overrides the weekday default) from the absence of a row (fall through to weekday default).
+const getCookSchedulesQuery = `
+    SELECT
+        TO_CHAR(d.date, 'YYYY-MM-DD'),
+        p.id,
+        CASE
+            WHEN cs.date IS NOT NULL THEN cs.cook_user_id
+            ELSE cds.cook_user_id
+        END,
+        u.name
+    FROM generate_series($1::date, $2::date, '1 day') AS d(date)
+    CROSS JOIN (VALUES (1), (2)) AS p(id)
+    LEFT JOIN cook_schedules cs ON cs.date = d.date AND cs.meal_period = p.id
+    LEFT JOIN cook_default_schedules cds
+        ON cds.day_of_week = EXTRACT(DOW FROM d.date) AND cds.meal_period = p.id
+    LEFT JOIN users u ON u.id = CASE
+        WHEN cs.date IS NOT NULL THEN cs.cook_user_id
+        ELSE cds.cook_user_id
+    END
+    ORDER BY d.date, p.id`
+
+// getCookSchedules returns resolved cook assignments for a date range.
+func getCookSchedules(c *gin.Context) {
+	dateParam := c.Query("date")
+	daysParam := c.Query("days")
+
+	startDate, err := time.Parse("2006-01-02", dateParam)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid date format. Use YYYY-MM-DD."})
+		return
+	}
+	days, err := strconv.Atoi(daysParam)
+	if err != nil || days < 1 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid days parameter. Must be a positive integer."})
+		return
+	}
+	endDate := startDate.AddDate(0, 0, days-1).Format("2006-01-02")
+
+	rows, err := db.Query(getCookSchedulesQuery, startDate.Format("2006-01-02"), endDate)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	defer rows.Close()
+
+	result := make(map[string]*DailyCookSchedule)
+	for rows.Next() {
+		var dateStr string
+		var mealPeriod int
+		var cookUserID sql.NullInt64
+		var cookUserName sql.NullString
+		if err := rows.Scan(&dateStr, &mealPeriod, &cookUserID, &cookUserName); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if _, ok := result[dateStr]; !ok {
+			result[dateStr] = &DailyCookSchedule{}
+		}
+		var assignment *CookAssignment
+		if cookUserID.Valid {
+			assignment = &CookAssignment{
+				CookUserID:   int(cookUserID.Int64),
+				CookUserName: cookUserName.String,
+			}
+		}
+		if mealPeriod == 1 {
+			result[dateStr].Lunch = assignment
+		} else {
+			result[dateStr].Dinner = assignment
+		}
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+const bulkUpdateCookSchedulesStmt = `INSERT INTO cook_schedules (date, meal_period, cook_user_id)
+VALUES ($1, $2, $3)
+ON CONFLICT (date, meal_period) DO UPDATE SET cook_user_id = EXCLUDED.cook_user_id`
+
+// bulkUpdateCookSchedules upserts individual date cook assignments.
+func bulkUpdateCookSchedules(c *gin.Context) {
+	var updates []CookScheduleUpdate
+	if err := c.ShouldBindJSON(&updates); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	stmt, err := tx.Prepare(bulkUpdateCookSchedulesStmt)
+	if err != nil {
+		tx.Rollback()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	defer stmt.Close()
+	for _, u := range updates {
+		var cookID interface{}
+		if u.CookUserID != nil {
+			cookID = *u.CookUserID
+		}
+		if _, err := stmt.Exec(u.Date, u.MealPeriod, cookID); err != nil {
+			tx.Rollback()
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "Cook schedules updated"})
+}
+
+const deleteCookSchedulesStmt = "DELETE FROM cook_schedules WHERE date = $1 AND meal_period = $2"
+
+// deleteCookSchedules removes individual date overrides, reverting to weekday defaults.
+func deleteCookSchedules(c *gin.Context) {
+	var entries []CookScheduleDelete
+	if err := c.ShouldBindJSON(&entries); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	stmt, err := tx.Prepare(deleteCookSchedulesStmt)
+	if err != nil {
+		tx.Rollback()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	defer stmt.Close()
+	for _, e := range entries {
+		if _, err := stmt.Exec(e.Date, e.MealPeriod); err != nil {
+			tx.Rollback()
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "Cook schedules deleted"})
+}
+
+const getCookDefaultSchedulesQuery = `SELECT cds.day_of_week, cds.meal_period, cds.cook_user_id, u.name
+FROM cook_default_schedules cds
+LEFT JOIN users u ON u.id = cds.cook_user_id
+ORDER BY cds.day_of_week, cds.meal_period`
+
+// getCookDefaultSchedules returns weekday-based default cook assignments.
+func getCookDefaultSchedules(c *gin.Context) {
+	rows, err := db.Query(getCookDefaultSchedulesQuery)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	defer rows.Close()
+	result := []CookDefaultSchedule{}
+	for rows.Next() {
+		var s CookDefaultSchedule
+		var cookUserID sql.NullInt64
+		var cookUserName sql.NullString
+		if err := rows.Scan(&s.DayOfWeek, &s.MealPeriod, &cookUserID, &cookUserName); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if cookUserID.Valid {
+			id := int(cookUserID.Int64)
+			s.CookUserID = &id
+		}
+		if cookUserName.Valid {
+			s.CookUserName = &cookUserName.String
+		}
+		result = append(result, s)
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+const updateCookDefaultSchedulesStmt = `INSERT INTO cook_default_schedules (day_of_week, meal_period, cook_user_id)
+VALUES ($1, $2, $3)
+ON CONFLICT (day_of_week, meal_period) DO UPDATE SET cook_user_id = EXCLUDED.cook_user_id`
+
+// updateCookDefaultSchedules upserts weekday-based default cook assignments.
+func updateCookDefaultSchedules(c *gin.Context) {
+	var entries []CookDefaultScheduleUpdate
+	if err := c.ShouldBindJSON(&entries); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	tx, err := db.Begin()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	stmt, err := tx.Prepare(updateCookDefaultSchedulesStmt)
+	if err != nil {
+		tx.Rollback()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	defer stmt.Close()
+	for _, e := range entries {
+		var cookID interface{}
+		if e.CookUserID != nil {
+			cookID = *e.CookUserID
+		}
+		if _, err := stmt.Exec(e.DayOfWeek, e.MealPeriod, cookID); err != nil {
+			tx.Rollback()
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"message": "Cook default schedules updated"})
+}
+
 func main() {
 	var err error
 	db, err = sql.Open("postgres", os.Getenv("DATABASE_URL"))
@@ -365,5 +634,10 @@ func main() {
 	r.PUT("/api/meals/bulk-update", bulkUpdateMeals)
 	r.GET("/api/user-defaults/:user_id", getUserDefaults)
 	r.PUT("/api/user-defaults/:user_id", updateUserDefaults)
+	r.GET("/api/cook-schedules", getCookSchedules)
+	r.PUT("/api/cook-schedules", bulkUpdateCookSchedules)
+	r.DELETE("/api/cook-schedules", deleteCookSchedules)
+	r.GET("/api/cook-default-schedules", getCookDefaultSchedules)
+	r.PUT("/api/cook-default-schedules", updateCookDefaultSchedules)
 	r.Run(":8080")
 }

--- a/backend/main_test.go
+++ b/backend/main_test.go
@@ -26,6 +26,11 @@ func setupRouter() *gin.Engine {
 	r.PUT("/api/meals/bulk-update", bulkUpdateMeals)
 	r.GET("/api/user-defaults/:user_id", getUserDefaults)
 	r.PUT("/api/user-defaults/:user_id", updateUserDefaults)
+	r.GET("/api/cook-schedules", getCookSchedules)
+	r.PUT("/api/cook-schedules", bulkUpdateCookSchedules)
+	r.DELETE("/api/cook-schedules", deleteCookSchedules)
+	r.GET("/api/cook-default-schedules", getCookDefaultSchedules)
+	r.PUT("/api/cook-default-schedules", updateCookDefaultSchedules)
 	return r
 }
 
@@ -286,4 +291,148 @@ func TestUpdateUserDefaults(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	expectedResp := `{"message":"User defaults updated"}`
 	assert.JSONEq(t, expectedResp, w.Body.String())
+}
+
+// TestGetCookSchedules verifies GET /api/cook-schedules.
+// Rows with a valid cook_user_id produce a CookAssignment object;
+// rows with NULL produce nil (各自) in the JSON response.
+func TestGetCookSchedules(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer mockDB.Close()
+	db = mockDB
+
+	rows := sqlmock.NewRows([]string{"date", "meal_period", "cook_user_id", "cook_user_name"}).
+		AddRow("2026-04-06", 1, 5, "Mother").
+		AddRow("2026-04-06", 2, nil, nil).
+		AddRow("2026-04-07", 1, nil, nil).
+		AddRow("2026-04-07", 2, 2, "Father")
+
+	mock.ExpectQuery(regexp.QuoteMeta(getCookSchedulesQuery)).
+		WithArgs("2026-04-06", "2026-04-07").
+		WillReturnRows(rows)
+
+	r := setupRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/cook-schedules?date=2026-04-06&days=2", nil)
+	r.ServeHTTP(w, req)
+	t.Log("\n", func() string { var b bytes.Buffer; json.Indent(&b, w.Body.Bytes(), "", "  "); return b.String() }())
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	expected := `{
+		"2026-04-06": {"lunch": {"cook_user_id": 5, "cook_user_name": "Mother"}, "dinner": null},
+		"2026-04-07": {"lunch": null, "dinner": {"cook_user_id": 2, "cook_user_name": "Father"}}
+	}`
+	assert.JSONEq(t, expected, w.Body.String())
+}
+
+// TestBulkUpdateCookSchedules verifies PUT /api/cook-schedules.
+func TestBulkUpdateCookSchedules(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer mockDB.Close()
+	db = mockDB
+
+	mock.ExpectBegin()
+	prep := mock.ExpectPrepare(regexp.QuoteMeta(bulkUpdateCookSchedulesStmt))
+	prep.ExpectExec().WithArgs("2026-04-06", 1, sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	prep.ExpectExec().WithArgs("2026-04-06", 2, sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	cookID := 5
+	updates := []CookScheduleUpdate{
+		{Date: "2026-04-06", MealPeriod: 1, CookUserID: &cookID},
+		{Date: "2026-04-06", MealPeriod: 2, CookUserID: nil},
+	}
+	payload, _ := json.Marshal(updates)
+	r := setupRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/cook-schedules", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	t.Log("\n", func() string { var b bytes.Buffer; json.Indent(&b, w.Body.Bytes(), "", "  "); return b.String() }())
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `{"message":"Cook schedules updated"}`, w.Body.String())
+}
+
+// TestDeleteCookSchedules verifies DELETE /api/cook-schedules.
+func TestDeleteCookSchedules(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer mockDB.Close()
+	db = mockDB
+
+	mock.ExpectBegin()
+	prep := mock.ExpectPrepare(regexp.QuoteMeta(deleteCookSchedulesStmt))
+	prep.ExpectExec().WithArgs("2026-04-06", 1).WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	entries := []CookScheduleDelete{{Date: "2026-04-06", MealPeriod: 1}}
+	payload, _ := json.Marshal(entries)
+	r := setupRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/api/cook-schedules", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	t.Log("\n", func() string { var b bytes.Buffer; json.Indent(&b, w.Body.Bytes(), "", "  "); return b.String() }())
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `{"message":"Cook schedules deleted"}`, w.Body.String())
+}
+
+// TestGetCookDefaultSchedules verifies GET /api/cook-default-schedules.
+func TestGetCookDefaultSchedules(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer mockDB.Close()
+	db = mockDB
+
+	rows := sqlmock.NewRows([]string{"day_of_week", "meal_period", "cook_user_id", "cook_user_name"}).
+		AddRow(1, 1, 5, "Mother").
+		AddRow(1, 2, 5, "Mother").
+		AddRow(3, 1, nil, nil)
+
+	mock.ExpectQuery(regexp.QuoteMeta(getCookDefaultSchedulesQuery)).WillReturnRows(rows)
+
+	r := setupRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/cook-default-schedules", nil)
+	r.ServeHTTP(w, req)
+	t.Log("\n", func() string { var b bytes.Buffer; json.Indent(&b, w.Body.Bytes(), "", "  "); return b.String() }())
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	expected := `[
+		{"day_of_week":1,"meal_period":1,"cook_user_id":5,"cook_user_name":"Mother"},
+		{"day_of_week":1,"meal_period":2,"cook_user_id":5,"cook_user_name":"Mother"},
+		{"day_of_week":3,"meal_period":1,"cook_user_id":null,"cook_user_name":null}
+	]`
+	assert.JSONEq(t, expected, w.Body.String())
+}
+
+// TestUpdateCookDefaultSchedules verifies PUT /api/cook-default-schedules.
+func TestUpdateCookDefaultSchedules(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	assert.NoError(t, err)
+	defer mockDB.Close()
+	db = mockDB
+
+	mock.ExpectBegin()
+	prep := mock.ExpectPrepare(regexp.QuoteMeta(updateCookDefaultSchedulesStmt))
+	prep.ExpectExec().WithArgs(1, 1, sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	prep.ExpectExec().WithArgs(1, 2, sqlmock.AnyArg()).WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	cookID := 5
+	entries := []CookDefaultScheduleUpdate{
+		{DayOfWeek: 1, MealPeriod: 1, CookUserID: &cookID},
+		{DayOfWeek: 1, MealPeriod: 2, CookUserID: nil},
+	}
+	payload, _ := json.Marshal(entries)
+	r := setupRouter()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/api/cook-default-schedules", bytes.NewBuffer(payload))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	t.Log("\n", func() string { var b bytes.Buffer; json.Indent(&b, w.Body.Bytes(), "", "  "); return b.String() }())
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `{"message":"Cook default schedules updated"}`, w.Body.String())
 }

--- a/db/02_init_schema.sql
+++ b/db/02_init_schema.sql
@@ -33,3 +33,21 @@ CREATE TABLE IF NOT EXISTS user_defaults (
     dinner INT,
     PRIMARY KEY (user_id, day_of_week)
 );
+
+-- Cook schedule: weekday-based default cook assignment per meal period.
+-- cook_user_id NULL means 各自 (no designated cook).
+CREATE TABLE IF NOT EXISTS cook_default_schedules (
+    day_of_week  INT NOT NULL,
+    meal_period  INT NOT NULL,
+    cook_user_id INT REFERENCES users(id) ON DELETE SET NULL,
+    PRIMARY KEY (day_of_week, meal_period)
+);
+
+-- Cook schedule: individual date override per meal period.
+-- cook_user_id NULL means explicitly 各自 (overrides any weekday default).
+CREATE TABLE IF NOT EXISTS cook_schedules (
+    date         DATE NOT NULL,
+    meal_period  INT  NOT NULL,
+    cook_user_id INT REFERENCES users(id) ON DELETE SET NULL,
+    PRIMARY KEY (date, meal_period)
+);

--- a/db/05_add_cook_schedules.sql
+++ b/db/05_add_cook_schedules.sql
@@ -1,0 +1,15 @@
+-- Migration: add cook_default_schedules and cook_schedules tables.
+-- Both tables are new; no existing tables are modified.
+CREATE TABLE IF NOT EXISTS cook_default_schedules (
+    day_of_week  INT NOT NULL,
+    meal_period  INT NOT NULL,
+    cook_user_id INT REFERENCES users(id) ON DELETE SET NULL,
+    PRIMARY KEY (day_of_week, meal_period)
+);
+
+CREATE TABLE IF NOT EXISTS cook_schedules (
+    date         DATE NOT NULL,
+    meal_period  INT  NOT NULL,
+    cook_user_id INT REFERENCES users(id) ON DELETE SET NULL,
+    PRIMARY KEY (date, meal_period)
+);

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,6 +17,11 @@
 | PUT | `/api/meals/bulk-update` | 複数食事予定の一括更新 |
 | GET | `/api/user-defaults/:user_id` | ユーザーのデフォルト設定取得 |
 | PUT | `/api/user-defaults/:user_id` | ユーザーのデフォルト設定更新 |
+| GET | `/api/cook-schedules` | 指定期間の料理担当（解決済み）取得 |
+| PUT | `/api/cook-schedules` | 日付別料理担当の個別設定 |
+| DELETE | `/api/cook-schedules` | 日付別個別設定の削除（デフォルトに戻す） |
+| GET | `/api/cook-default-schedules` | 曜日別デフォルト料理担当取得 |
+| PUT | `/api/cook-default-schedules` | 曜日別デフォルト料理担当更新 |
 
 ## 各エンドポイント詳細
 
@@ -145,3 +150,79 @@ DBへのping結果を返す。起動確認・死活監視用。
 ### PUT `/api/user-defaults/:user_id`
 
 ユーザーの曜日別デフォルト設定を更新する。リクエスト形式はGETのレスポンスと同じ。
+
+---
+
+### GET `/api/cook-schedules`
+
+指定期間内の料理担当を解決済みで返す。優先度：個別設定 → 曜日デフォルト → 各自（null）。
+
+**クエリパラメータ**
+
+| パラメータ | 必須 | 説明 |
+|---------|------|------|
+| `date` | 必須 | 開始日 (`YYYY-MM-DD`) |
+| `days` | 必須 | 取得日数（整数） |
+
+**レスポンス例**
+
+```json
+{
+  "2026-04-06": {
+    "lunch":  { "cook_user_id": 5, "cook_user_name": "Mother" },
+    "dinner": null
+  },
+  "2026-04-07": {
+    "lunch":  null,
+    "dinner": { "cook_user_id": 2, "cook_user_name": "Father" }
+  }
+}
+```
+
+`null` = 各自。フロントエンドはこの値を見て eater の dropdown / 「各自」テキスト表示を切り替える。
+
+---
+
+### PUT `/api/cook-schedules`
+
+日付別の料理担当を個別設定する（upsert）。`cook_user_id=null` で「各自」を曜日デフォルトより優先して上書き。
+
+```json
+[
+  { "date": "2026-04-06", "meal_period": 1, "cook_user_id": 5 },
+  { "date": "2026-04-06", "meal_period": 2, "cook_user_id": null }
+]
+```
+
+---
+
+### DELETE `/api/cook-schedules`
+
+個別設定を削除してデフォルトに戻す。
+
+```json
+[
+  { "date": "2026-04-06", "meal_period": 1 }
+]
+```
+
+---
+
+### GET `/api/cook-default-schedules`
+
+曜日別デフォルト設定を返す。登録のない曜日×区分は暗黙的に各自。
+
+```json
+[
+  { "day_of_week": 1, "meal_period": 1, "cook_user_id": 5, "cook_user_name": "Mother" },
+  { "day_of_week": 1, "meal_period": 2, "cook_user_id": null, "cook_user_name": null }
+]
+```
+
+`day_of_week` は 0=日曜〜6=土曜。`meal_period` は 1=昼 / 2=夜。
+
+---
+
+### PUT `/api/cook-default-schedules`
+
+曜日別デフォルト設定を更新する（upsert）。リクエスト形式は `cook_user_name` を除いた GET レスポンスと同じ。

--- a/docs/database.md
+++ b/docs/database.md
@@ -29,11 +29,23 @@ erDiagram
         int lunch
         int dinner
     }
+    cook_default_schedules {
+        int day_of_week PK
+        int meal_period PK
+        int cook_user_id FK
+    }
+    cook_schedules {
+        date date PK
+        int meal_period PK
+        int cook_user_id FK
+    }
 
     users ||--o{ meals : ""
     users ||--o{ user_defaults : ""
     meal_periods ||--o{ meals : ""
     meal_options ||--o{ meals : ""
+    users ||--o{ cook_default_schedules : ""
+    users ||--o{ cook_schedules : ""
 ```
 
 ## テーブル定義
@@ -110,3 +122,33 @@ PK: `(user_id, day_of_week)`
 **設計上のポイント**
 
 `meals` テーブルには「実際に変更した日」だけを記録する。登録のない日は `user_defaults` で補完することで、毎週同じ予定を都度入力する手間をなくしている。
+
+---
+
+### `cook_default_schedules`
+
+曜日別・食事区分別の料理担当デフォルト設定。
+
+| カラム | 型 | 制約 |
+|-------|-----|------|
+| day_of_week | INT | PK、0=日〜6=土 |
+| meal_period | INT | PK、1=昼/2=夜 |
+| cook_user_id | INT | FK → users、NULL=各自 |
+
+登録のない曜日×区分は暗黙的に「各自」扱い。
+
+---
+
+### `cook_schedules`
+
+日付別・食事区分別の料理担当個別設定。`cook_default_schedules` より優先される。
+
+| カラム | 型 | 制約 |
+|-------|-----|------|
+| date | DATE | PK |
+| meal_period | INT | PK、1=昼/2=夜 |
+| cook_user_id | INT | FK → users、NULL=各自 |
+
+`cook_user_id=NULL` の行は「この日は各自」を明示的に指定する。デフォルトに戻すには行を DELETE する。
+
+**優先度：** `cook_schedules`（行あり） → `cook_default_schedules` → 各自（暗黙）

--- a/frontend/public/cook-defaults.html
+++ b/frontend/public/cook-defaults.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <title>コック設定</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      font-size: 16px;
+      margin: 0;
+      padding: 12px;
+      background: #f5f5f5;
+    }
+    h1 {
+      font-size: 1.2em;
+      margin: 0 0 16px 0;
+    }
+    .card {
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.12);
+      padding: 14px 16px;
+      margin-bottom: 14px;
+    }
+    .table-container {
+      overflow-x: auto;
+    }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      min-width: 280px;
+    }
+    th, td {
+      border: 1px solid #e0e0e0;
+      padding: 7px 10px;
+      text-align: center;
+      white-space: nowrap;
+      font-size: 0.95em;
+    }
+    th {
+      background-color: #f2f2f2;
+      font-weight: normal;
+      color: #555;
+    }
+    select {
+      font-size: 1em;
+      padding: 2px 4px;
+      width: 100%;
+    }
+    .saved-msg {
+      font-size: 0.75em;
+      color: #4caf50;
+      margin-top: 8px;
+      min-height: 1em;
+    }
+    .back-link {
+      display: inline-block;
+      margin-top: 6px;
+      color: #555;
+      font-size: 0.9em;
+      text-decoration: none;
+    }
+    .back-link:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <h1>コック設定</h1>
+  <div class="card">
+    <div class="table-container">
+      <table id="defaultsTable">
+        <thead>
+          <tr>
+            <th>曜日</th>
+            <th>昼</th>
+            <th>夜</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td colspan="3">読み込み中...</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="saved-msg" id="savedMsg"></div>
+  </div>
+
+  <a class="back-link" href="/">← スケジュールに戻る</a>
+
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script>
+    const weekdayNames = ['日', '月', '火', '水', '木', '金', '土'];
+    let cookUsers = [];
+    let defaultsMap = {};
+
+    function buildSelect(classes, day, selectedUserId) {
+      const $select = $('<select></select>')
+        .addClass(classes)
+        .attr('data-day', day);
+      $select.append($('<option></option>').val('').text('各自'));
+      cookUsers.forEach(function(u) {
+        const $opt = $('<option></option>').val(u.id).text(u.name);
+        if (u.id === selectedUserId) $opt.prop('selected', true);
+        $select.append($opt);
+      });
+      return $select;
+    }
+
+    function renderDefaults() {
+      const $tbody = $('#defaultsTable tbody');
+      $tbody.empty();
+      for (let day = 0; day <= 6; day++) {
+        const row = defaultsMap[day] || { lunch_cook_user_id: null, dinner_cook_user_id: null };
+        const $tr = $('<tr></tr>');
+        $tr.append($('<td></td>').text(weekdayNames[day]));
+        $tr.append($('<td></td>').append(buildSelect('lunchDefault', day, row.lunch_cook_user_id)));
+        $tr.append($('<td></td>').append(buildSelect('dinnerDefault', day, row.dinner_cook_user_id)));
+        $tbody.append($tr);
+      }
+    }
+
+    function loadAll() {
+      $.when(
+        $.ajax({ url: '/api/users' }),
+        $.ajax({ url: '/api/cook-default-schedules' })
+      ).done(function(usersRes, defaultsRes) {
+        cookUsers = usersRes[0].filter(function(u) { return u.is_cook; });
+        defaultsMap = {};
+        defaultsRes[0].forEach(function(row) {
+          if (!defaultsMap[row.day_of_week]) {
+            defaultsMap[row.day_of_week] = { lunch_cook_user_id: null, dinner_cook_user_id: null };
+          }
+          if (row.meal_period === 1) {
+            defaultsMap[row.day_of_week].lunch_cook_user_id = row.cook_user_id;
+          } else if (row.meal_period === 2) {
+            defaultsMap[row.day_of_week].dinner_cook_user_id = row.cook_user_id;
+          }
+        });
+        renderDefaults();
+      }).fail(function() {
+        alert('データの読み込みに失敗しました');
+      });
+    }
+
+    $(document).on('change', 'select.lunchDefault, select.dinnerDefault', function() {
+      const day = parseInt($(this).attr('data-day'));
+      const lunchVal = $('select.lunchDefault[data-day="' + day + '"]').val();
+      const dinnerVal = $('select.dinnerDefault[data-day="' + day + '"]').val();
+
+      const payload = [
+        { day_of_week: day, meal_period: 1, cook_user_id: lunchVal === '' ? null : parseInt(lunchVal) },
+        { day_of_week: day, meal_period: 2, cook_user_id: dinnerVal === '' ? null : parseInt(dinnerVal) }
+      ];
+
+      $.ajax({
+        url: '/api/cook-default-schedules',
+        method: 'PUT',
+        contentType: 'application/json',
+        data: JSON.stringify(payload),
+        success: function() {
+          $('#savedMsg').text('保存しました').fadeIn(200).delay(1500).fadeOut(400);
+          loadAll();
+        },
+        error: function() {
+          alert('保存に失敗しました');
+        }
+      });
+    });
+
+    $(document).ready(function() {
+      loadAll();
+    });
+  </script>
+</body>
+</html>

--- a/frontend/public/daily.html
+++ b/frontend/public/daily.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <title>日別ダッシュボード</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      font-size: 16px;
+      margin: 0;
+      padding: 12px;
+      background: #f5f5f5;
+    }
+    .nav {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 14px;
+    }
+    .nav a {
+      text-decoration: none;
+      color: #333;
+      font-size: 1.1em;
+      padding: 4px 12px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      background: #fff;
+    }
+    .nav a:hover { background: #eee; }
+    .nav-label {
+      font-size: 0.85em;
+      color: #888;
+    }
+    .card {
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.12);
+      padding: 14px 16px;
+      margin-bottom: 16px;
+      overflow-x: auto;
+    }
+    .card-date {
+      font-size: 1.1em;
+      font-weight: bold;
+      margin-bottom: 10px;
+    }
+    .day-label {
+      display: inline-block;
+      margin-left: 8px;
+      font-size: 0.75em;
+      font-weight: normal;
+      color: #fff;
+      background: #5c8fc9;
+      border-radius: 10px;
+      padding: 1px 8px;
+      vertical-align: middle;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      min-width: 240px;
+    }
+    th, td {
+      border: 1px solid #e0e0e0;
+      padding: 7px 10px;
+      text-align: center;
+      font-size: 0.95em;
+      white-space: nowrap;
+    }
+    th {
+      background: #f2f2f2;
+      font-weight: normal;
+      color: #555;
+    }
+    th.period-header {
+      width: 3em;
+    }
+    td.cook-cell select {
+      font-size: 1em;
+      padding: 2px 4px;
+      width: 100%;
+    }
+    td.kakuji {
+      color: #bbb;
+      font-style: italic;
+    }
+    .summary {
+      margin-top: 8px;
+      font-size: 0.82em;
+      color: #555;
+      line-height: 1.9;
+    }
+    .saved-msg {
+      font-size: 0.75em;
+      color: #4caf50;
+      text-align: right;
+      margin-top: 4px;
+      min-height: 1em;
+    }
+    .back-link {
+      display: inline-block;
+      margin-top: 4px;
+      color: #555;
+      font-size: 0.9em;
+      text-decoration: none;
+    }
+    .back-link:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+
+  <div class="nav">
+    <a id="prevLink" href="#">&lt; 前日</a>
+    <span class="nav-label" id="navLabel"></span>
+    <a id="nextLink" href="#">翌日 &gt;</a>
+  </div>
+
+  <div id="dailyContainer">
+    <div class="card"><div style="color:#aaa">読み込み中...</div></div>
+  </div>
+
+  <a class="back-link" href="/">← スケジュールに戻る</a>
+
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script>
+    const weekdayNames = ['日', '月', '火', '水', '木', '金', '土'];
+    const mealOptionText  = { 1: 'なし', 2: '家',    3: '弁当'    };
+    const mealOptionIcon  = { 1: '',     2: '🏠',    3: '🍱'      };
+    const mealOptionLabel = { 1: 'なし', 2: '🏠 家', 3: '🍱 弁当' };
+
+    function getQueryParam(name) {
+      return new URLSearchParams(window.location.search).get(name);
+    }
+    function getTodayStr() {
+      const d = new Date();
+      return d.getFullYear() + '-' +
+        String(d.getMonth() + 1).padStart(2, '0') + '-' +
+        String(d.getDate()).padStart(2, '0');
+    }
+    function addDays(dateStr, n) {
+      const d = new Date(dateStr + 'T00:00:00');
+      d.setDate(d.getDate() + n);
+      return d.getFullYear() + '-' +
+        String(d.getMonth() + 1).padStart(2, '0') + '-' +
+        String(d.getDate()).padStart(2, '0');
+    }
+    function formatDateDisplay(dateStr) {
+      const d = new Date(dateStr + 'T00:00:00');
+      const mm = String(d.getMonth() + 1).padStart(2, '0');
+      const dd = String(d.getDate()).padStart(2, '0');
+      return mm + '/' + dd + '（' + weekdayNames[d.getDay()] + '）';
+    }
+
+    // Base date from URL param, defaulting to today
+    const todayStr   = getTodayStr();
+    const baseDate   = getQueryParam('date') || todayStr;
+    const targetDates = [baseDate, addDays(baseDate, 1), addDays(baseDate, 2)];
+
+    // Relative day labels — only attach when date truly matches today/tomorrow/day-after
+    const tomorrow    = addDays(todayStr, 1);
+    const dayAfter    = addDays(todayStr, 2);
+    function getDayLabel(dateStr) {
+      if (dateStr === todayStr) return '今日';
+      if (dateStr === tomorrow)  return '明日';
+      if (dateStr === dayAfter)  return '明後日';
+      return null;
+    }
+
+    // Navigation
+    $('#prevLink').attr('href', '/daily.html?date=' + addDays(baseDate, -1));
+    $('#nextLink').attr('href', '/daily.html?date=' + addDays(baseDate,  1));
+    $('#navLabel').text(formatDateDisplay(baseDate) + ' 〜');
+
+    let cookUsers = [];
+
+    function buildCookSelect(dateStr, mealPeriod, selectedUserId) {
+      let html = '<select class="cookSelect" data-date="' + dateStr + '" data-meal-period="' + mealPeriod + '">';
+      html += '<option value="">各自</option>';
+      cookUsers.forEach(function(u) {
+        const sel = (u.id === selectedUserId) ? ' selected' : '';
+        html += '<option value="' + u.id + '"' + sel + '>' + u.name + '</option>';
+      });
+      html += '</select>';
+      return html;
+    }
+
+    function buildSummary(cookDay, mealsDay, eaterUsers) {
+      const mealMap = {};
+      mealsDay.forEach(function(m) { mealMap[m.user_id] = m; });
+
+      const periods = [
+        { label: '昼', cookEntry: cookDay ? cookDay.lunch  : null, mealKey: 'lunch',  defaultKey: 'defaultLunch'  },
+        { label: '夜', cookEntry: cookDay ? cookDay.dinner : null, mealKey: 'dinner', defaultKey: 'defaultDinner' }
+      ];
+
+      const lines = [];
+      periods.forEach(function(p) {
+        const isKakuji = !p.cookEntry;
+        if (isKakuji) {
+          lines.push(p.label + ': 各自:' + eaterUsers.length + '人');
+          return;
+        }
+        const counts = {};
+        eaterUsers.forEach(function(user) {
+          const m = mealMap[user.id] || { lunch: 0, dinner: 0, defaultLunch: 1, defaultDinner: 1 };
+          const raw = m[p.mealKey];
+          const def = m[p.defaultKey];
+          const val = (raw === 0 || raw === undefined) ? (def || 1) : raw;
+          counts[val] = (counts[val] || 0) + 1;
+        });
+        const parts = [];
+        [3, 2, 1].forEach(function(key) {
+          if (counts[key]) {
+            parts.push((mealOptionIcon[key] || '') + mealOptionText[key] + ':' + counts[key] + '人');
+          }
+        });
+        lines.push(p.label + ': ' + (parts.join('、') || '-'));
+      });
+      return lines.join('<br>');
+    }
+
+    function renderDay(dateStr, cookDay, mealsDay, eaterUsers, cardIndex) {
+      const mealMap = {};
+      mealsDay.forEach(function(m) { mealMap[m.user_id] = m; });
+
+      const periods = [
+        { label: '昼', period: 1, cookEntry: cookDay ? cookDay.lunch  : null, mealKey: 'lunch',  defaultKey: 'defaultLunch'  },
+        { label: '夜', period: 2, cookEntry: cookDay ? cookDay.dinner : null, mealKey: 'dinner', defaultKey: 'defaultDinner' }
+      ];
+
+      // Header
+      let headerHtml = '<tr><th class="period-header"></th><th>コック</th>';
+      eaterUsers.forEach(function(u) { headerHtml += '<th>' + u.name + '</th>'; });
+      headerHtml += '</tr>';
+
+      // Body
+      let bodyHtml = '';
+      periods.forEach(function(p) {
+        const isKakuji = !p.cookEntry;
+        const cookId   = p.cookEntry ? p.cookEntry.cook_user_id : null;
+        bodyHtml += '<tr>';
+        bodyHtml += '<th class="period-header">' + p.label + '</th>';
+        bodyHtml += '<td class="cook-cell">' + buildCookSelect(dateStr, p.period, cookId) + '</td>';
+        eaterUsers.forEach(function(user) {
+          if (isKakuji) {
+            bodyHtml += '<td class="kakuji">各自</td>';
+          } else {
+            const m = mealMap[user.id] || { lunch: 0, dinner: 0, defaultLunch: 1, defaultDinner: 1 };
+            const raw = m[p.mealKey];
+            const def = m[p.defaultKey];
+            const val = (raw === 0 || raw === undefined) ? (def || 1) : raw;
+            bodyHtml += '<td>' + (mealOptionLabel[val] || '-') + '</td>';
+          }
+        });
+        bodyHtml += '</tr>';
+      });
+
+      const label    = getDayLabel(dateStr);
+      const labelHtml = label ? '<span class="day-label">' + label + '</span>' : '';
+      const savedId  = 'savedMsg-' + cardIndex;
+      const summary  = buildSummary(cookDay, mealsDay, eaterUsers);
+
+      return '<div class="card">' +
+        '<div class="card-date">' + formatDateDisplay(dateStr) + labelHtml + '</div>' +
+        '<table><thead>' + headerHtml + '</thead><tbody>' + bodyHtml + '</tbody></table>' +
+        '<div class="summary">' + summary + '</div>' +
+        '<div class="saved-msg" id="' + savedId + '"></div>' +
+        '</div>';
+    }
+
+    function loadAll() {
+      $.when(
+        $.ajax({ url: '/api/users' }),
+        $.ajax({ url: '/api/cook-schedules', data: { date: baseDate, days: 3 } }),
+        $.ajax({ url: '/api/meals',          data: { date: baseDate, days: 3 } })
+      ).done(function(usersRes, cookRes, mealsRes) {
+        const users     = usersRes[0];
+        const cookData  = cookRes[0]  || {};
+        const mealsData = mealsRes[0] || {};
+
+        cookUsers = users.filter(function(u) { return u.is_cook; });
+        const eaterUsers = users.filter(function(u) { return u.is_eater; });
+
+        let html = '';
+        targetDates.forEach(function(dateStr, i) {
+          const cookDay  = cookData[dateStr]  || null;
+          const mealsDay = mealsData[dateStr] || [];
+          html += renderDay(dateStr, cookDay, mealsDay, eaterUsers, i);
+        });
+        $('#dailyContainer').html(html);
+      }).fail(function() {
+        alert('データの読み込みに失敗しました');
+      });
+    }
+
+    $(document).on('change', '.cookSelect', function() {
+      const dateStr    = $(this).attr('data-date');
+      const mealPeriod = parseInt($(this).attr('data-meal-period'));
+      const val        = $(this).val();
+      const cookUserId = val === '' ? null : parseInt(val);
+      const cardIndex  = targetDates.indexOf(dateStr);
+
+      $.ajax({
+        url: '/api/cook-schedules',
+        method: 'PUT',
+        contentType: 'application/json',
+        data: JSON.stringify([{ date: dateStr, meal_period: mealPeriod, cook_user_id: cookUserId }]),
+        success: function() {
+          if (cardIndex >= 0) {
+            $('#savedMsg-' + cardIndex).text('保存しました').fadeIn(200).delay(1500).fadeOut(400);
+          }
+          loadAll();
+        },
+        error: function() { alert('保存に失敗しました'); }
+      });
+    });
+
+    $(document).ready(function() { loadAll(); });
+  </script>
+</body>
+</html>

--- a/frontend/public/script.js
+++ b/frontend/public/script.js
@@ -1,5 +1,7 @@
 // Global variable to store schedule data.
 let scheduleData = null;
+// Global variable to store cook schedule data.
+let cookScheduleData = null;
 // Global language setting; default is Japanese.
 let currentLang = "ja";
 
@@ -67,7 +69,7 @@ $('#languageSelect').change(function() {
   setCookie("lang", currentLang, 365);
   updateLanguage();
   if (scheduleData !== null) {
-    renderSchedule(scheduleData);
+    renderSchedule(scheduleData, cookScheduleData);
   }
 });
 
@@ -103,27 +105,25 @@ $(document).ready(function() {
     3: "弁当"
   };
 
-  // Load schedule from backend.
+  // Load schedule from backend (meals and cook schedules in parallel).
   function loadSchedule() {
     const startDate = $('#startDate').val();
     const days = $('#days').val();
-    $.ajax({
-      url: '/api/meals',
-      method: 'GET',
-      data: { date: startDate, days: days },
-      success: function(data) {
-        scheduleData = data;
-        renderSchedule(data);
-      },
-      error: function(err) {
-        alert('Failed to load schedule.');
-        console.error(err);
-      }
+    $.when(
+      $.ajax({ url: '/api/meals', method: 'GET', data: { date: startDate, days: days } }),
+      $.ajax({ url: '/api/cook-schedules', method: 'GET', data: { date: startDate, days: days } })
+    ).done(function(mealsResult, cookResult) {
+      scheduleData = mealsResult[0];
+      cookScheduleData = cookResult[0];
+      renderSchedule(scheduleData, cookScheduleData);
+    }).fail(function(err) {
+      alert('Failed to load schedule.');
+      console.error(err);
     });
   }
 
   // Render schedule table.
-  function renderSchedule(data) {
+  function renderSchedule(data, cookData) {
     $('#scheduleContainer').empty();
     const dates = Object.keys(data).sort();
     if (dates.length === 0) {
@@ -136,14 +136,14 @@ $(document).ready(function() {
     const users = firstDateMeals.slice().sort((a, b) => a.user_id - b.user_id);
 
     let tableHtml = '<table>';
-    // Header row 1: Date | each user (as link with colspan=2)
-    tableHtml += '<thead><tr><th>' + translations[currentLang].dateHeader + '</th>';
+    // Header row 1: Cook defaults link | each user (as link with colspan=2)
+    tableHtml += '<thead><tr><th><a href="/cook-defaults.html">コック</a></th>';
     users.forEach(user => {
       tableHtml += '<th colspan="2"><a href="/user-defaults.html?user_id=' + user.user_id + '">' + user.user_name + '</a></th>';
     });
     tableHtml += '</tr>';
-    // Header row 2: empty cell, then Lunch and Dinner for each user.
-    tableHtml += '<tr><th></th>';
+    // Header row 2: Date | Lunch/Dinner for each user.
+    tableHtml += '<tr><th>' + translations[currentLang].dateHeader + '</th>';
     users.forEach(() => {
       tableHtml += '<th>' + translations[currentLang].lunchHeader + '</th><th>' + translations[currentLang].dinnerHeader + '</th>';
     });
@@ -164,7 +164,12 @@ $(document).ready(function() {
       if (weekday === 0) dateClass = "sunday";
       else if (weekday === 6) dateClass = "saturday";
       else dateClass = "weekday";
-      tableHtml += '<td class="' + dateClass + '">' + dateDisplay + '</td>';
+      tableHtml += '<td class="' + dateClass + '"><a href="/daily.html?date=' + date + '">' + dateDisplay + '</a></td>';
+
+      // Cook info for this date.
+      const cookDay = (cookData && cookData[date]) ? cookData[date] : { lunch: null, dinner: null };
+      const lunchCook = cookDay.lunch;
+      const dinnerCook = cookDay.dinner;
 
       // Create a mapping for this date.
       const mealMapping = {};
@@ -173,46 +178,35 @@ $(document).ready(function() {
       });
 
       users.forEach(user => {
-        // The API returns numeric values.
         const meal = mealMapping[user.user_id] || { lunch: 0, dinner: 0, defaultLunch: 0, defaultDinner: 0 };
-        // If no data (value 0), use default.
         const displayedLunch = meal.lunch === 0 ? meal.defaultLunch : meal.lunch;
         const displayedDinner = meal.dinner === 0 ? meal.defaultDinner : meal.dinner;
-        // Determine cell classes.
-        let lunchCellClass = "";
-        let dinnerCellClass = "";
-        if (meal.lunch === 0) {
-          lunchCellClass = "cell-gray";
-        } else if (meal.lunch !== meal.defaultLunch) {
-          lunchCellClass = "cell-highlight";
-        }
-        if (meal.dinner === 0) {
-          dinnerCellClass = "cell-gray";
-        } else if (meal.dinner !== meal.defaultDinner) {
-          dinnerCellClass = "cell-highlight";
-        }
-        // Build lunch dropdown.
-        let lunchSelect = '<select class="lunchSelect" data-user-id="' + user.user_id + '" data-date="' + date + '">';
-        for (let key in mealOptions) {
-          lunchSelect += '<option value="' + key + '"';
-          if (displayedLunch === parseInt(key)) {
-            lunchSelect += ' selected';
+
+        // Lunch cell: show 各自 text when no cook assigned.
+        if (!lunchCook) {
+          tableHtml += '<td class="cell-kakuji">各自</td>';
+        } else {
+          let lunchCellClass = meal.lunch === 0 ? "cell-gray" : (meal.lunch !== meal.defaultLunch ? "cell-highlight" : "");
+          let lunchSelect = '<select class="lunchSelect" data-user-id="' + user.user_id + '" data-date="' + date + '">';
+          for (let key in mealOptions) {
+            lunchSelect += '<option value="' + key + '"' + (displayedLunch === parseInt(key) ? ' selected' : '') + '>' + mealOptions[key] + '</option>';
           }
-          lunchSelect += '>' + mealOptions[key] + '</option>';
+          lunchSelect += '</select>';
+          tableHtml += '<td class="' + lunchCellClass + '">' + lunchSelect + '</td>';
         }
-        lunchSelect += '</select>';
-        // Build dinner dropdown.
-        let dinnerSelect = '<select class="dinnerSelect" data-user-id="' + user.user_id + '" data-date="' + date + '">';
-        for (let key in mealOptions) {
-          dinnerSelect += '<option value="' + key + '"';
-          if (displayedDinner === parseInt(key)) {
-            dinnerSelect += ' selected';
+
+        // Dinner cell: show 各自 text when no cook assigned.
+        if (!dinnerCook) {
+          tableHtml += '<td class="cell-kakuji">各自</td>';
+        } else {
+          let dinnerCellClass = meal.dinner === 0 ? "cell-gray" : (meal.dinner !== meal.defaultDinner ? "cell-highlight" : "");
+          let dinnerSelect = '<select class="dinnerSelect" data-user-id="' + user.user_id + '" data-date="' + date + '">';
+          for (let key in mealOptions) {
+            dinnerSelect += '<option value="' + key + '"' + (displayedDinner === parseInt(key) ? ' selected' : '') + '>' + mealOptions[key] + '</option>';
           }
-          dinnerSelect += '>' + mealOptions[key] + '</option>';
+          dinnerSelect += '</select>';
+          tableHtml += '<td class="' + dinnerCellClass + '">' + dinnerSelect + '</td>';
         }
-        dinnerSelect += '</select>';
-        tableHtml += '<td class="' + lunchCellClass + '">' + lunchSelect + '</td>';
-        tableHtml += '<td class="' + dinnerCellClass + '">' + dinnerSelect + '</td>';
       });
       tableHtml += '</tr>';
     });

--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -127,3 +127,10 @@ table td:not(.sunday):not(.saturday) {
 .cell-gray {
   background-color: #f2f2f2 !important;
 }
+
+/* Cell shown when no cook is assigned (各自) */
+.cell-kakuji {
+  background-color: #f9f9f9 !important;
+  color: #aaa;
+  font-size: 0.85em;
+}

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -73,6 +73,83 @@ app.put('/api/user-defaults/:user_id', async (req, res) => {
   }
 });
 
+// Proxy endpoint for GET /api/users
+app.get('/api/users', async (req, res) => {
+  try {
+    const response = await axios.get(`${BACKEND_API_BASE}/users`);
+    res.json(response.data);
+  } catch (error) {
+    console.error('Error fetching users:', error.message);
+    res.status(500).json({ error: 'Failed to fetch users from backend' });
+  }
+});
+
+// Proxy endpoint for PUT /api/users/:user_id/roles
+app.put('/api/users/:user_id/roles', async (req, res) => {
+  try {
+    const response = await axios.put(`${BACKEND_API_BASE}/users/${req.params.user_id}/roles`, req.body);
+    res.json(response.data);
+  } catch (error) {
+    console.error('Error updating user roles:', error.message);
+    res.status(500).json({ error: 'Failed to update user roles in backend' });
+  }
+});
+
+// Proxy endpoint for GET /api/cook-schedules
+app.get('/api/cook-schedules', async (req, res) => {
+  try {
+    const response = await axios.get(`${BACKEND_API_BASE}/cook-schedules`, { params: req.query });
+    res.json(response.data);
+  } catch (error) {
+    console.error('Error fetching cook schedules:', error.message);
+    res.status(500).json({ error: 'Failed to fetch cook schedules from backend' });
+  }
+});
+
+// Proxy endpoint for PUT /api/cook-schedules
+app.put('/api/cook-schedules', async (req, res) => {
+  try {
+    const response = await axios.put(`${BACKEND_API_BASE}/cook-schedules`, req.body);
+    res.json(response.data);
+  } catch (error) {
+    console.error('Error updating cook schedules:', error.message);
+    res.status(500).json({ error: 'Failed to update cook schedules in backend' });
+  }
+});
+
+// Proxy endpoint for DELETE /api/cook-schedules
+app.delete('/api/cook-schedules', async (req, res) => {
+  try {
+    const response = await axios.delete(`${BACKEND_API_BASE}/cook-schedules`, { params: req.query });
+    res.json(response.data);
+  } catch (error) {
+    console.error('Error deleting cook schedules:', error.message);
+    res.status(500).json({ error: 'Failed to delete cook schedules from backend' });
+  }
+});
+
+// Proxy endpoint for GET /api/cook-default-schedules
+app.get('/api/cook-default-schedules', async (req, res) => {
+  try {
+    const response = await axios.get(`${BACKEND_API_BASE}/cook-default-schedules`);
+    res.json(response.data);
+  } catch (error) {
+    console.error('Error fetching cook default schedules:', error.message);
+    res.status(500).json({ error: 'Failed to fetch cook default schedules from backend' });
+  }
+});
+
+// Proxy endpoint for PUT /api/cook-default-schedules
+app.put('/api/cook-default-schedules', async (req, res) => {
+  try {
+    const response = await axios.put(`${BACKEND_API_BASE}/cook-default-schedules`, req.body);
+    res.json(response.data);
+  } catch (error) {
+    console.error('Error updating cook default schedules:', error.message);
+    res.status(500).json({ error: 'Failed to update cook default schedules in backend' });
+  }
+});
+
 // Serve index.html on the root path
 app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));


### PR DESCRIPTION
  ---
  Description

  ## Summary

  Adds cook schedule management so the designated cook (Mother) can be marked as unavailable on specific dates. When no cook is assigned for a meal period, eater cells
   display "各自" (fend for themselves) instead of meal dropdowns.

  ### Backend
  - New tables: `cook_schedules` (date-specific overrides) and `cook_default_schedules` (weekday defaults)
  - Priority resolution via SQL: `cook_schedules` → `cook_default_schedules` → null (各自)
    - An explicit NULL row in `cook_schedules` overrides the weekday default (forces 各自)
  - New API endpoints:
    - `GET /api/users` — list all users with `is_cook` / `is_eater` flags
    - `PUT /api/users/:user_id/roles` — update cook/eater roles
    - `GET|PUT|DELETE /api/cook-schedules` — date-specific cook assignments
    - `GET|PUT /api/cook-default-schedules` — weekday default cook assignments
  - DB migration: `db/05_add_cook_schedules.sql` (apply before deploying)
  - Unit tests (sqlmock) and integration tests (testcontainers) added for all new endpoints

  ### Frontend
  - `script.js`: fetches cook schedules in parallel with meals; shows 各自 cells when no cook is assigned; date cells link to daily dashboard
  - `daily.html`: 3-day dashboard (today + 2 days, navigable); unified table with rows=昼/夜 and columns=コック+users; meal icons (🏠 家 / 🍱 弁当); per-period summary
   counts; 今日/明日/明後日 badges
  - `cook-defaults.html`: weekday default cook settings (コック設定)
  - `server.js`: proxy routes added for all new API endpoints

  ## Deploy order

  1. Apply migration: `db/05_add_cook_schedules.sql`
  2. Deploy backend
  3. Deploy frontend

  ---

  ## 概要

  担当コック（Mother）がごはんを作れない日を設定できるコックスケジュール管理機能を追加します。料理担当が設定されていない食事回は、食事予定のドロップダウンの代わりに「  各自」が表示されます。

  ### バックエンド
  - 新テーブル: `cook_schedules`（日付単位の上書き）、`cook_default_schedules`（曜日デフォルト）
  - SQLによる優先順位解決: `cook_schedules` → `cook_default_schedules` → null（各自）
    - `cook_schedules` への明示的 NULL 行は曜日デフォルトを上書きして各自を強制
  - 新APIエンドポイント:
    - `GET /api/users` — `is_cook` / `is_eater` フラグ付きユーザー一覧
    - `PUT /api/users/:user_id/roles` — コック/イーター役割の更新
    - `GET|PUT|DELETE /api/cook-schedules` — 日付単位のコック割り当て
    - `GET|PUT /api/cook-default-schedules` — 曜日デフォルトのコック割り当て
  - DBマイグレーション: `db/05_add_cook_schedules.sql`（デプロイ前に適用必須）
  - 全新エンドポイントに対してユニットテスト（sqlmock）・インテグレーションテスト（testcontainers）を追加

  ### フロントエンド
  - `script.js`: コックスケジュールを食事データと並列取得、コック未設定時は各自セル表示、日付セルからデイリーダッシュボードへリンク
  - `daily.html`: 3日分ダッシュボード（基準日は URL の `?date=`、前日/翌日ナビ付き）、行=昼/夜・列=コック+ユーザーの統合テーブル、食事アイコン（🏠 家 / 🍱
  弁当）、期間別人数サマリ、今日/明日/明後日バッジ
  - `cook-defaults.html`: 曜日デフォルトのコック設定ページ
  - `server.js`: 全新エンドポイントのプロキシルートを追加

  ## デプロイ順序

  1. マイグレーション適用: `db/05_add_cook_schedules.sql`
  2. バックエンドをデプロイ
  3. フロントエンドをデプロイ